### PR TITLE
Fixing query filtering via checkbox behavior

### DIFF
--- a/query_prototype/static/css/query_prototype.css
+++ b/query_prototype/static/css/query_prototype.css
@@ -84,3 +84,8 @@ Purpose: Stylesheet for query prototype
     padding-bottom: 1em;
 }
 
+#repo-row {
+ 
+    padding-bottom: 1em;
+}
+

--- a/query_prototype/static/js/query_prototype.js
+++ b/query_prototype/static/js/query_prototype.js
@@ -8,15 +8,12 @@ class QueryPrototypeResultsHandler {
     // static id_resultsCheckAll = "#dataset-checkall";
     // static class_resultsCheckbox = ".dataset-checkbox";
 
+    static data_list = [];
+
     constructor(p_queryID) {
 
         // 1. Define instance fields
-        this.data_list = [];
-        this.data_json = {
-
-            "query": parseInt(p_queryID),
-            "datasets": this.data_list
-        };
+        this.queryID = parseInt(p_queryID);
 
         // 2. Initialize class instance
         this.setup();
@@ -25,10 +22,7 @@ class QueryPrototypeResultsHandler {
 
     addEventListeners() {
 
-        // 1. Save reference to this.data_list for use in event listeners
-        let data_list = this.data_list;
-
-        // 2. Add event listeners
+        // 1. Add event listeners
 
         // A. Check all checkbox
         $("#dataset-checkall").click(function () {
@@ -41,7 +35,7 @@ class QueryPrototypeResultsHandler {
 
                 // a. Add each corresponding dataset ID to the data list
                 $(".dataset-checkbox").each(function(i, obj) {
-                    data_list.push($(this).attr("id"));
+                    QueryPrototypeResultsHandler.data_list.push($(this).attr("id"));
                 });
 
                 // b. Make the download results button visible
@@ -50,7 +44,7 @@ class QueryPrototypeResultsHandler {
             else {
 
                 // a. Clear the data list
-                data_list = [];
+                QueryPrototypeResultsHandler.data_list = [];
 
                 // b. Hide the download results button
                 $("#download-results-button").css("visibility", "hidden");
@@ -68,17 +62,14 @@ class QueryPrototypeResultsHandler {
 
     addEventListenersCheckboxes(){
 
-        // 1. Save reference to this.data_list for use in event listeners
-        let data_list = this.data_list;
-
-        // 2. Define individual checkbox clicking behavior (not check all checkbox)
+        // 1. Define individual checkbox clicking behavior (not check all checkbox)
         $(".dataset-checkbox").not("#dataset-checkall").click(function() {
             
             // A. If checked, add the dataset id to the data list
             if ( $(this).prop("checked") ) {
                 
                 // a. Add this dataset's ID to the data list
-                data_list.push($(this).attr("id"));
+                QueryPrototypeResultsHandler.data_list.push($(this).attr("id"));
 
                 // b. Make the download results button visible
                 $("#download-results-button").css("visibility", "visible");
@@ -87,22 +78,27 @@ class QueryPrototypeResultsHandler {
             else {
                 
                 // a. Remove this dataset's ID from the data list
-                let index = data_list.indexOf($(this).attr("id"));
-                if ( -1 == index ) {
-                    data_list.splice(index, 1);
+                let index = QueryPrototypeResultsHandler.data_list.indexOf($(this).attr("id"));
+                if ( index > -1 ) {
+                    QueryPrototypeResultsHandler.data_list.splice(index, 1);
                 }
 
                 // b. Hide the download results button
-                $("#download-results-button").css("visibility", "hidden");
+                if ( 0 == QueryPrototypeResultsHandler.data_list.length ) {
+                    $("#download-results-button").css("visibility", "hidden");
+                }
             }
         });
-
     }
 
     downloadCsv() {
 
-        this.sendPostWithData(`${location.origin}/query_prototype/download_csv/`, JSON.stringify(this.data_json), "text/csv");
-        // window.location = `${location.origin}/query_prototype/download_csv/`;
+        var data_json = {
+            
+            "query": this.queryID,
+            "datasets": QueryPrototypeResultsHandler.data_list
+        }
+        this.sendPostWithData(`${location.origin}/query_prototype/download_csv/`, JSON.stringify(data_json), "text/csv");
     }
 
     sendPostWithData(p_url, p_data, p_contentType) {
@@ -122,28 +118,36 @@ class QueryPrototypeResultsHandler {
                 //     alert("it didnt work");
                 // }
                 success: function(blob, status, xhr) {
-                    // check for a filename
+                    
+                    // 1. Check for a filename
                     var filename = "";
                     var disposition = xhr.getResponseHeader('Content-Disposition');
-                    if (disposition && disposition.indexOf('attachment') !== -1) {
+
+                    if ( disposition && disposition.indexOf('attachment' ) !== -1 ) {
+                        
                         var filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
                         var matches = filenameRegex.exec(disposition);
-                        if (matches != null && matches[1]) filename = matches[1].replace(/['"]/g, '');
+                        
+                        if ( matches != null && matches[1] ) {
+                            filename = matches[1].replace(/['"]/g, '');
+                        }
                     }
             
                     if (typeof window.navigator.msSaveBlob !== 'undefined') {
                         // IE workaround for "HTML7007: One or more blob URLs were revoked by closing the blob for which they were created. These URLs will no longer resolve as the data backing the URL has been freed."
                         window.navigator.msSaveBlob(blob, filename);
                     } else {
+
                         var URL = window.URL || window.webkitURL;
-                        // var actualBlob = new Blob(blob);
                         var fileObj = new File([blob], filename, {type: p_contentType})
                         var downloadUrl = URL.createObjectURL(fileObj);
             
-                        if (filename) {
-                            // use HTML5 a[download] attribute to specify filename
+                        if ( filename ) {
+
+                            // Use HTML5 a[download] attribute to specify filename
                             var a = document.createElement("a");
-                            // safari doesn't support this yet
+
+                            // Safari doesn't support this yet
                             if (typeof a.download === 'undefined') {
                                 window.location.href = downloadUrl;
                             } else {

--- a/query_prototype/templates/query_results_new.html
+++ b/query_prototype/templates/query_results_new.html
@@ -77,7 +77,7 @@
 
                                 <div class="col-4">
 
-                                    <div class="row">
+                                    <div class="row" id="repo-row">
                                         <div class="card-dataset-source d-flex justify-content-end"><a href="{{ result.repo }}">{{ result.repo }}</a></div>
                                     </div>
 


### PR DESCRIPTION
Checkboxes now select/deselect appropriately and a bug in the JS event listener code now correctly stores the dataset IDs of those checkboxes currently selected